### PR TITLE
Release v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "reviewprompt",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
 	"keywords": [
 		"ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,7 +10,7 @@ const program = new Command();
 program
   .name("reviewprompt")
   .description("GitHub PR review comments to AI prompt CLI tool")
-  .version("0.2.0");
+  .version("0.3.0");
 
 program
   .argument("<pr-url>", "GitHub PR URL")

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -74,16 +74,14 @@ describe("Integration Tests", () => {
     // Step 2: Format comments for prompt
     const formattedComments = filteredComments.map(formatCommentForPrompt);
     expect(formattedComments[0]).toBe(
-      "# ./src/auth.ts:L40-L42\n# Fix this bug in the authentication logic",
+      "./src/auth.ts:L40-L42\nFix this bug in the authentication logic",
     );
-    expect(formattedComments[1]).toBe(
-      "# ./src/utils.ts:L25\n# Add unit tests for this new function",
-    );
+    expect(formattedComments[1]).toBe("./src/utils.ts:L25\nAdd unit tests for this new function");
 
     // Step 3: Build final prompt
     const prompt = buildPrompt(filteredComments);
     expect(prompt).toBe(
-      "# ./src/auth.ts:L40-L42\n# Fix this bug in the authentication logic\n# =====\n# ./src/utils.ts:L25\n# Add unit tests for this new function",
+      "./src/auth.ts:L40-L42\nFix this bug in the authentication logic\n=====\n./src/utils.ts:L25\nAdd unit tests for this new function",
     );
 
     // Step 4: Display prompt
@@ -206,9 +204,9 @@ describe("Integration Tests", () => {
 
     const formatted = testComments.map(formatCommentForPrompt);
 
-    expect(formatted[0]).toBe("# ./src/test.ts:L42\n# Single line comment");
-    expect(formatted[1]).toBe("# ./src/test.ts:L42-L45\n# Range comment");
-    expect(formatted[2]).toBe("# General comment");
+    expect(formatted[0]).toBe("./src/test.ts:L42\nSingle line comment");
+    expect(formatted[1]).toBe("./src/test.ts:L42-L45\nRange comment");
+    expect(formatted[2]).toBe("General comment");
   });
 
   it("should test command option combinations", () => {

--- a/src/lib/comment.test.ts
+++ b/src/lib/comment.test.ts
@@ -165,7 +165,7 @@ describe("formatCommentForPrompt", () => {
     };
 
     const result = formatCommentForPrompt(comment);
-    expect(result).toBe("# Fix this bug");
+    expect(result).toBe("Fix this bug");
   });
 
   it("should format comment with path and single line", () => {
@@ -183,7 +183,7 @@ describe("formatCommentForPrompt", () => {
     };
 
     const result = formatCommentForPrompt(comment);
-    expect(result).toBe("# ./src/test.ts:L42\n# Fix this bug");
+    expect(result).toBe("./src/test.ts:L42\nFix this bug");
   });
 
   it("should format comment with path and line range", () => {
@@ -202,7 +202,7 @@ describe("formatCommentForPrompt", () => {
     };
 
     const result = formatCommentForPrompt(comment);
-    expect(result).toBe("# ./src/test.ts:L42-L45\n# Fix this bug");
+    expect(result).toBe("./src/test.ts:L42-L45\nFix this bug");
   });
 
   it("should format comment with path and same start/end line", () => {
@@ -221,7 +221,7 @@ describe("formatCommentForPrompt", () => {
     };
 
     const result = formatCommentForPrompt(comment);
-    expect(result).toBe("# ./src/test.ts:L42\n# Fix this bug");
+    expect(result).toBe("./src/test.ts:L42\nFix this bug");
   });
 
   it("should format comment with path and only start line", () => {
@@ -239,7 +239,7 @@ describe("formatCommentForPrompt", () => {
     };
 
     const result = formatCommentForPrompt(comment);
-    expect(result).toBe("# ./src/test.ts:L42\n# Fix this bug");
+    expect(result).toBe("./src/test.ts:L42\nFix this bug");
   });
 
   it("should not include path info when path exists but no line info", () => {
@@ -256,6 +256,6 @@ describe("formatCommentForPrompt", () => {
     };
 
     const result = formatCommentForPrompt(comment);
-    expect(result).toBe("# Fix this bug");
+    expect(result).toBe("Fix this bug");
   });
 });

--- a/src/lib/comment.ts
+++ b/src/lib/comment.ts
@@ -39,8 +39,8 @@ export function formatCommentForPrompt(comment: FilteredComment): string {
         ? `L${comment.startLine}-L${comment.line}`
         : `L${comment.line || comment.startLine}`;
 
-    return `# ./${comment.path}:${lineInfo}\n# ${cleanBody}`;
+    return `./${comment.path}:${lineInfo}\n${cleanBody}`;
   }
 
-  return `# ${cleanBody}`;
+  return `${cleanBody}`;
 }

--- a/src/utils/example.test.ts
+++ b/src/utils/example.test.ts
@@ -23,7 +23,7 @@ describe("buildPrompt", () => {
     ];
 
     const result = buildPrompt(comments);
-    expect(result).toBe("# Fix this bug");
+    expect(result).toBe("Fix this bug");
   });
 
   it("should build prompt for multiple comments with separator", () => {
@@ -51,7 +51,7 @@ describe("buildPrompt", () => {
     ];
 
     const result = buildPrompt(comments);
-    expect(result).toBe("# Fix this bug\n# =====\n# Add tests");
+    expect(result).toBe("Fix this bug\n=====\nAdd tests");
   });
 
   it("should handle comments with path and line info", () => {
@@ -71,7 +71,7 @@ describe("buildPrompt", () => {
     ];
 
     const result = buildPrompt(comments);
-    expect(result).toBe("# ./src/test.ts:L42\n# Fix this bug");
+    expect(result).toBe("./src/test.ts:L42\nFix this bug");
   });
 });
 

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -11,7 +11,7 @@ export function buildPrompt(comments: FilteredComment[]): string {
     content: formatCommentForPrompt(comment),
   }));
 
-  return sections.map((section) => section.content).join("\n# =====\n");
+  return sections.map((section) => section.content).join("\n=====\n");
 }
 
 export function displayPrompt(prompt: string): void {


### PR DESCRIPTION
## Release v0.3.0

This release removes the unnecessary `#` prefix from the reviewprompt command output to provide cleaner formatting.

### Changes
- Remove `#` prefix from file paths, comment content, and separators in reviewprompt output
- Update all tests to match the new output format

### Example Output Before:
```
# ./src/auth.ts:L40-L42
# Fix this bug in the authentication logic
# =====
# ./src/utils.ts:L25
# Add unit tests for this new function
```

### Example Output After:
```
./src/auth.ts:L40-L42
Fix this bug in the authentication logic
=====
./src/utils.ts:L25
Add unit tests for this new function
```

🤖 Generated with [Claude Code](https://claude.ai/code)