### PR TITLE
Add --prune flag to git pull in merge-pr command

### DIFF
--- a/.rulesync/commands/merge-pr.md
+++ b/.rulesync/commands/merge-pr.md
@@ -71,7 +71,7 @@ After merging:
 If the local branch exists, please clean up the local branch. Execute:
 
 ```bash
-git checkout main && git pull && git branch -d <branch-name>
+git checkout main && git pull --prune && git branch -d <branch-name>
 ```
 
 Where `<branch-name>` is the head branch name from Step 2 (e.g., `fix/rulesync-import-targets`).


### PR DESCRIPTION
## Summary
- Added `--prune` flag to `git pull` command in merge-pr cleanup step
- This removes stale remote-tracking branches that no longer exist on the remote

## Changes
- Modified `.rulesync/commands/merge-pr.md` to include `--prune` flag

## Benefits
- Keeps local git repository clean by removing obsolete remote-tracking branches
- Prevents accumulation of stale branch references over time