### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+updates:
+  # Automatic updates for npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 1
+    open-pull-requests-limit: 2
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "automated"
+    reviewers:
+      - "dyoshikawa"
+      - "cm-dyoshikawa"
+    allow:
+      - dependency-type: "all"
+
+  # Automatic updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 1
+    open-pull-requests-limit: 1
+    groups:
+      all-actions:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "actions/checkout"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "ci"
+      - "automated"
+    reviewers:
+      - "dyoshikawa"
+      - "cm-dyoshikawa"

--- a/cspell.json
+++ b/cspell.json
@@ -163,6 +163,7 @@
 		"testrepo",
 		"tlsv",
 		"cicheck",
+		"cooldown",
 		"OPENROUTER",
 		"ZHIPU",
 		"bubblewrap",


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for automated npm and GitHub Actions updates
- Configure weekly dependency updates with cooldown period
- Group all dependencies together to reduce PR noise
- Add "cooldown" to cspell dictionary as it's a valid Dependabot keyword

## Details
- **npm updates**: Weekly schedule, grouped dependencies, 2 concurrent PRs limit
- **GitHub Actions updates**: Weekly schedule, grouped actions, 1 PR limit
- **Reviewers**: dyoshikawa, cm-dyoshikawa
- **Cooldown**: 1 day default to avoid overwhelming with updates
- **Labels**: dependencies/automated for npm, ci/automated for GitHub Actions

## Test Plan
- Dependabot will automatically create PRs when dependency updates are available
- Configuration can be verified via GitHub repository settings > Dependabot