### PR TITLE
Add Bun single binary support with E2E tests and release workflow

### DIFF
--- a/.github/workflows/e2e-binaries.yml
+++ b/.github/workflows/e2e-binaries.yml
@@ -35,7 +35,7 @@ jobs:
           experimental: true
 
       - name: Install dependencies
-        run: bun install
+        run: pnpm install
 
       - name: Build binaries
         run: |

--- a/.github/workflows/e2e-binaries.yml
+++ b/.github/workflows/e2e-binaries.yml
@@ -35,7 +35,7 @@ jobs:
           experimental: true
 
       - name: Install dependencies
-        run: pnpm install
+        run: bun install
 
       - name: Build binaries
         run: |

--- a/.github/workflows/e2e-binaries.yml
+++ b/.github/workflows/e2e-binaries.yml
@@ -1,0 +1,110 @@
+name: E2E Tests on Cross-Platform
+
+on:
+  push:
+    branches: [main]
+    paths-ignore: &paths-ignore
+      - "**/*.md"
+      - "images/**"
+      - ".devcontainer/**"
+      - ".vscode/**"
+      - ".zed/**"
+      - "LICENSE"
+      - "cspell.json"
+      - ".cspellcache"
+      - ".secretlintrc.json"
+  pull_request:
+    branches: [main]
+    paths-ignore: *paths-ignore
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build binaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+
+      - name: Setup mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8
+        with:
+          experimental: true
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build binaries
+        run: |
+          mkdir -p dist-bun
+          bun build --compile --minify --sourcemap --target=bun-linux-x64 --outfile=dist-bun/reviewprompt-linux-x64 ./src/cli/index.ts
+          bun build --compile --minify --sourcemap --target=bun-linux-arm64 --outfile=dist-bun/reviewprompt-linux-arm64 ./src/cli/index.ts
+          bun build --compile --minify --sourcemap --target=bun-darwin-arm64 --outfile=dist-bun/reviewprompt-darwin-arm64 ./src/cli/index.ts
+          bun build --compile --minify --sourcemap --target=bun-darwin-x64 --outfile=dist-bun/reviewprompt-darwin-x64 ./src/cli/index.ts
+          bun build --compile --minify --sourcemap --target=bun-windows-x64 --outfile=dist-bun/reviewprompt-windows-x64.exe ./src/cli/index.ts
+
+      - name: Cache binaries
+        uses: actions/cache/save@8b402f58fbc84540c8b491a91e594a4576fec3d7
+        with:
+          path: dist-bun
+          key: reviewprompt-binaries-${{ github.sha }}
+          enableCrossOsArchive: true
+
+  e2e:
+    name: E2E Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+
+      - name: Restore cached binaries
+        uses: actions/cache/restore@8b402f58fbc84540c8b491a91e594a4576fec3d7
+        with:
+          path: dist-bun
+          key: reviewprompt-binaries-${{ github.sha }}
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+
+      - name: Make binary executable (Unix)
+        if: runner.os != 'Windows'
+        env:
+          MATRIX_OS: ${{ matrix.os }}
+        run: |
+          if [ "$MATRIX_OS" = "ubuntu-latest" ]; then
+            chmod +x dist-bun/reviewprompt-linux-x64
+            BINARY_PATH=dist-bun/reviewprompt-linux-x64
+          elif [ "$MATRIX_OS" = "macos-latest" ]; then
+            chmod +x dist-bun/reviewprompt-darwin-arm64
+            BINARY_PATH=dist-bun/reviewprompt-darwin-arm64
+          else
+            chmod +x dist-bun/reviewprompt-darwin-x64
+            BINARY_PATH=dist-bun/reviewprompt-darwin-x64
+          fi
+          echo "BINARY_PATH=$BINARY_PATH" >> $GITHUB_ENV
+
+      - name: Set binary path (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "BINARY_PATH=dist-bun/reviewprompt-windows-x64.exe" >> $GITHUB_ENV
+
+      - name: Setup mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8
+        with:
+          experimental: true
+
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts
+
+      - name: Test binary
+        env:
+          REVIEWPROMPT_CMD: ${{ env.BINARY_PATH }}
+        run: pnpm test:e2e

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,53 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  build-binaries:
+    name: Build and upload binaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        with:
+          ref: main
+
+      - name: Setup mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8
+        with:
+          experimental: true
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build binaries
+        run: |
+          mkdir -p dist-bun
+          bun build --compile --minify --sourcemap --target=bun-linux-x64 --outfile=dist-bun/reviewprompt-linux-x64 ./src/cli/index.ts
+          bun build --compile --minify --sourcemap --target=bun-linux-arm64 --outfile=dist-bun/reviewprompt-linux-arm64 ./src/cli/index.ts
+          bun build --compile --minify --sourcemap --target=bun-darwin-arm64 --outfile=dist-bun/reviewprompt-darwin-arm64 ./src/cli/index.ts
+          bun build --compile --minify --sourcemap --target=bun-darwin-x64 --outfile=dist-bun/reviewprompt-darwin-x64 ./src/cli/index.ts
+          bun build --compile --minify --sourcemap --target=bun-windows-x64 --outfile=dist-bun/reviewprompt-windows-x64.exe ./src/cli/index.ts
+
+      - name: Generate checksums
+        run: |
+          cd dist-bun
+          sha256sum reviewprompt-* > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Upload binaries to release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        with:
+          files: |
+            dist-bun/reviewprompt-linux-x64
+            dist-bun/reviewprompt-linux-arm64
+            dist-bun/reviewprompt-darwin-arm64
+            dist-bun/reviewprompt-darwin-x64
+            dist-bun/reviewprompt-windows-x64.exe
+            dist-bun/SHA256SUMS

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -24,7 +24,7 @@ jobs:
           experimental: true
 
       - name: Install dependencies
-        run: bun install
+        run: pnpm install
 
       - name: Build binaries
         run: |

--- a/cspell.json
+++ b/cspell.json
@@ -182,6 +182,8 @@
 		"OOXML",
 		"mnda",
 		"arcname",
-		"zipf"
+		"zipf",
+		"elif",
+		"softprops"
 	]
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "sort": "sort-package-json",
         "test": "vitest run --silent",
         "test:coverage": "vitest run --coverage --silent",
+        "test:e2e": "vitest run --config vitest.e2e.config.ts --silent=false",
         "test:watch": "vitest --silent",
         "typecheck": "tsgo --noEmit",
         "prepare": "simple-git-hooks && pnpm dlx rulesync@latest generate"

--- a/src/e2e/e2e.spec.ts
+++ b/src/e2e/e2e.spec.ts
@@ -1,0 +1,53 @@
+import { execFile } from "node:child_process";
+import { join, sep } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+// Get the command to run from environment variable
+// Default to using tsx directly with the CLI entry point
+const originalCwd = process.cwd();
+const tsxPath = join(originalCwd, "node_modules", ".bin", "tsx");
+const cliPath = join(originalCwd, "src", "cli", "index.ts");
+
+// Validate process.env.REVIEWPROMPT_CMD
+if (process.env.REVIEWPROMPT_CMD) {
+  const resolvedReviewpromptCmd = join(originalCwd, process.env.REVIEWPROMPT_CMD);
+  const splittedResolvedReviewpromptCmd = resolvedReviewpromptCmd.split(sep);
+  const valid =
+    splittedResolvedReviewpromptCmd.at(-2) === "dist-bun" &&
+    splittedResolvedReviewpromptCmd.at(-1)?.startsWith("reviewprompt-");
+  if (!valid) {
+    throw new Error(
+      `Invalid REVIEWPROMPT_CMD: must start with 'dist-bun' directory and end with 'reviewprompt-<platform>-<arch>': ${process.env.REVIEWPROMPT_CMD}`,
+    );
+  }
+}
+
+// Convert relative path to absolute path if REVIEWPROMPT_CMD is set
+const reviewpromptCmd = process.env.REVIEWPROMPT_CMD
+  ? join(originalCwd, process.env.REVIEWPROMPT_CMD)
+  : tsxPath;
+const reviewpromptArgs = process.env.REVIEWPROMPT_CMD ? [] : [cliPath];
+
+describe("E2E Tests", () => {
+  it("should display version with --version", async () => {
+    const { stdout } = await execFileAsync(reviewpromptCmd, [...reviewpromptArgs, "--version"]);
+
+    const versionMatch = stdout.trim().match(/(\d+\.\d+\.\d+)/);
+    expect(versionMatch).toBeTruthy();
+    expect(versionMatch?.[1]).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("should display help with --help", async () => {
+    const { stdout } = await execFileAsync(reviewpromptCmd, [...reviewpromptArgs, "--help"]);
+
+    expect(stdout).toContain("GitHub PR review comments to AI prompt CLI tool");
+    expect(stdout).toContain("Commands:");
+  });
+
+  it("should display error for missing PR URL", async () => {
+    await expect(execFileAsync(reviewpromptCmd, reviewpromptArgs)).rejects.toThrow();
+  });
+});

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/e2e/**/*.spec.ts"],
+    testTimeout: 60000,
+    hookTimeout: 60000,
+    watch: false,
+    maxWorkers: 1,
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## Summary
- Add E2E test suite (src/e2e/e2e.spec.ts) for basic CLI functionality
- Add E2E vitest configuration (vitest.e2e.config.ts)
- Add cross-platform E2E workflow (.github/workflows/e2e-binaries.yml)
- Add release workflow for binary distribution (.github/workflows/release-binaries.yml)
- Add test:e2e script to package.json
- Update cspell.json with 'elif' and 'softprops' words

These changes enable building and distributing Bun-compiled single binaries
for multiple platforms (Linux x64/arm64, macOS x64/arm64, Windows x64).

Closes #15