### PR TITLE
chore: add generic automation workflows and rulesync commands/skills

### DIFF
--- a/.github/workflows/auto-close-stale-prs.yml
+++ b/.github/workflows/auto-close-stale-prs.yml
@@ -1,0 +1,51 @@
+name: Auto Close Stale Pull Requests
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write # Required for commenting on and closing PRs
+
+concurrency:
+  group: auto-close-stale-prs
+  cancel-in-progress: false
+
+jobs:
+  close-stale-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Close pull requests inactive for more than 30 days
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const STALE_DAYS = 30;
+            const staleThresholdMs = STALE_DAYS * 24 * 60 * 60 * 1000;
+            const now = Date.now();
+            const { owner, repo } = context.repo;
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: "open", per_page: 100,
+            });
+            const stalePrs = prs.filter((pr) =>
+              now - new Date(pr.updated_at).getTime() >= staleThresholdMs);
+
+            core.info(`Found ${stalePrs.length} PR(s) inactive for more than ${STALE_DAYS} days.`);
+            for (const pr of stalePrs) {
+              try {
+                const mention = pr.user && pr.user.login ? `@${pr.user.login} ` : "";
+                const body = [
+                  `${mention}This pull request has had no activity for more than ${STALE_DAYS} days and is being closed automatically.`,
+                  "",
+                  "If this work is still relevant, feel free to reopen it or open a new pull request. Thank you for your contribution!",
+                ].join("\n");
+                await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+                await github.rest.pulls.update({ owner, repo, pull_number: pr.number, state: "closed" });
+                core.info(`Closed PR #${pr.number} (last updated at ${pr.updated_at}).`);
+              } catch (error) {
+                core.warning(`Failed to close PR #${pr.number}: ${error.message}`);
+              }
+            }

--- a/.github/workflows/ci-failure-reminder.yml
+++ b/.github/workflows/ci-failure-reminder.yml
@@ -1,0 +1,76 @@
+name: CI Failure Reminder
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write # Required for commenting on PRs
+  checks: read # Required for reading check run conclusions
+  statuses: read # Required for reading combined commit statuses
+
+concurrency:
+  group: ci-failure-reminder
+  cancel-in-progress: false
+
+jobs:
+  remind-ci-failures:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Comment on PRs with failing CI
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const REMINDER_MARKER = "ci-failure-reminder";
+            const failingConclusions = new Set(["failure", "timed_out"]);
+            const { owner, repo } = context.repo;
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: "open", per_page: 100,
+            });
+
+            let commentedCount = 0;
+            for (const pr of prs) {
+              if (pr.draft || !pr.user) continue;
+              if (pr.user.type === "Bot") continue;
+
+              const headSha = pr.head.sha;
+              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+                owner, repo, ref: headSha, per_page: 100,
+              });
+              const hasFailingCheckRun = checkRuns.some((run) =>
+                failingConclusions.has(run.conclusion));
+
+              let hasFailingStatus = false;
+              try {
+                const { data: combinedStatus } =
+                  await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref: headSha });
+                hasFailingStatus = combinedStatus.state === "failure";
+              } catch (error) {
+                core.warning(`Failed to fetch combined status for PR #${pr.number}: ${error.message}`);
+              }
+              if (!hasFailingCheckRun && !hasFailingStatus) continue;
+
+              const marker = `<!-- ${REMINDER_MARKER}:${headSha} -->`;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: pr.number, per_page: 100,
+              });
+              if (comments.some((c) => c.body && c.body.includes(marker))) {
+                core.info(`PR #${pr.number} already reminded for ${headSha}; skipping.`);
+                continue;
+              }
+
+              const body = [
+                `@${pr.user.login} The CI checks on this pull request are currently failing.`,
+                "",
+                "Please review the failing checks and push a fix. If you need help, leave a comment and a maintainer will follow up.",
+                "",
+                marker,
+              ].join("\n");
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+              commentedCount += 1;
+            }
+            core.info(`Posted ${commentedCount} CI-failure reminder(s).`);

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,52 @@
+name: PR Policy
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write # Required for commenting on PRs
+
+jobs:
+  check-policy:
+    name: External Contributor Policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Safety: do not check out or execute PR code in this job.
+      - name: Check contributor policy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          EVENT_ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          if [ "$AUTHOR_ASSOCIATION" = "OWNER" ] || [ "$AUTHOR_ASSOCIATION" = "MEMBER" ] || [ "$AUTHOR_ASSOCIATION" = "COLLABORATOR" ]; then
+            echo "Author is $AUTHOR_ASSOCIATION — skipping policy checks."
+            exit 0
+          fi
+
+          MAX_ADDITIONS=1000
+          MAX_OPEN_PRS=2
+          PR_ADDITIONS=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.additions')
+
+          if [ "$PR_ADDITIONS" -gt "$MAX_ADDITIONS" ]; then
+            COMMENT_BODY="Thank you for your contribution! Unfortunately, this PR has ${PR_ADDITIONS} added lines, which exceeds the limit of ${MAX_ADDITIONS} lines for external contributors. Please split your changes into smaller PRs. See https://github.com/${GH_REPO}/blob/main/CONTRIBUTING.md for details."
+            gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
+            echo "::warning::PR exceeds addition limit ($PR_ADDITIONS > $MAX_ADDITIONS)."
+          fi
+
+          if [ "$EVENT_ACTION" = "opened" ] || [ "$EVENT_ACTION" = "reopened" ]; then
+            OPEN_PR_COUNT=$(gh pr list --author "$PR_AUTHOR" --state open --json number --jq 'length')
+            if [ "$OPEN_PR_COUNT" -gt "$MAX_OPEN_PRS" ]; then
+              COMMENT_BODY="Thank you for your contribution! You currently have ${OPEN_PR_COUNT} open PRs, which exceeds the limit of ${MAX_OPEN_PRS} for external contributors. Please wait for an existing PR to be reviewed/merged before opening a new one."
+              gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
+              echo "::warning::Author has too many open PRs ($OPEN_PR_COUNT > $MAX_OPEN_PRS)."
+            fi
+          fi
+          echo "All policy checks passed."

--- a/.rulesync/commands/approve.md
+++ b/.rulesync/commands/approve.md
@@ -1,0 +1,30 @@
+---
+targets:
+  - "*"
+description: Approve a pull request with gh pr review --approve
+---
+
+# Approve Pull Request
+
+## Step 1: Determine the Target PR
+
+Parse `$ARGUMENTS`. If a PR number or URL is provided, use it. Otherwise use the
+PR associated with the current branch:
+
+```bash
+gh pr view --json number,title,state
+```
+
+If the PR cannot be determined, **ask the user** which PR to approve.
+
+## Step 2: Approve
+
+```bash
+gh pr review <pr_number> --approve
+```
+
+Optionally pass a short approval message with `--body "<message>"`.
+
+## Step 3: Report Result
+
+Output the approved PR number and title.

--- a/.rulesync/commands/diff-analyze.md
+++ b/.rulesync/commands/diff-analyze.md
@@ -1,0 +1,35 @@
+---
+targets:
+  - "*"
+description: Summarize the diff between the current branch and origin/main
+---
+
+# Analyze Diff Against origin/main
+
+## Step 1: Refresh the Base Reference
+
+```bash
+git fetch origin main
+```
+
+## Step 2: Inspect the Diff
+
+```bash
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD
+```
+
+The three-dot form compares the current branch against the common ancestor with
+`origin/main`, so unrelated changes already on `main` are excluded.
+
+## Step 3: Summarize
+
+Produce a concise summary covering:
+
+- The overall intent of the changes.
+- Notable additions, modifications, and removals grouped by area/module.
+- Any risks, follow-ups, or missing test coverage you notice.
+
+## Step 4: Report Result
+
+Output the summary. Do not modify any files.

--- a/.rulesync/commands/explain-issue.md
+++ b/.rulesync/commands/explain-issue.md
@@ -1,0 +1,36 @@
+---
+targets:
+  - "*"
+description: Explain the background and a proposed solution for a GitHub issue
+---
+
+# Explain Issue
+
+target_issue = $ARGUMENTS
+
+If `target_issue` is not provided, **ask the user** which issue to explain.
+
+## Step 1: Fetch the Issue
+
+```bash
+gh issue view <target_issue> --json title,body,labels,comments
+```
+
+## Step 2: Investigate Context
+
+Investigate the relevant code and discussion to understand the problem:
+
+- Which files/modules are affected.
+- Related patterns, prior art, and constraints.
+
+## Step 3: Explain
+
+Produce a clear explanation covering:
+
+- **Background**: what the issue is asking for and why.
+- **Root cause / context**: the relevant code and constraints.
+- **Proposed solution**: a concrete approach, with alternatives if relevant.
+
+## Step 4: Report Result
+
+Output the explanation. Do not modify any files.

--- a/.rulesync/commands/explain-pr.md
+++ b/.rulesync/commands/explain-pr.md
@@ -1,0 +1,36 @@
+---
+targets:
+  - "*"
+description: Explain the background and intent of a pull request
+---
+
+# Explain Pull Request
+
+target_pr = $ARGUMENTS
+
+If `target_pr` is not provided, use the PR of the current branch.
+
+## Important: Do Not Switch the Local Branch
+
+Inspect the PR with read-only commands; do not check out or switch the branch:
+
+```bash
+gh pr view <target_pr> --json title,body,files,commits
+gh pr diff <target_pr>
+```
+
+## Step 1: Understand the Change
+
+Review the description, commits, and diff to understand the intent.
+
+## Step 2: Explain
+
+Produce a clear explanation covering:
+
+- **Background**: the problem this PR addresses.
+- **What changed**: the key changes grouped by area/module.
+- **Impact / risks**: behavioral changes, migration notes, and follow-ups.
+
+## Step 3: Report Result
+
+Output the explanation and the PR number. Do not modify any files.

--- a/.rulesync/commands/post-issue-comment.md
+++ b/.rulesync/commands/post-issue-comment.md
@@ -1,0 +1,35 @@
+---
+targets:
+  - "*"
+description: Post a natural-language reply to a GitHub issue
+---
+
+# Post Issue Comment
+
+target_issue = $ARGUMENTS
+
+If `target_issue` is not provided, **ask the user** which issue to comment on.
+
+## Step 1: Read the Issue
+
+```bash
+gh issue view <target_issue> --json title,body,comments
+```
+
+Understand the current state of the discussion before replying.
+
+## Step 2: Draft the Comment
+
+Write the comment in natural English. Keep it clear, friendly, and specific to
+the discussion. Confirm the draft with the user before posting if there is any
+ambiguity about intent.
+
+## Step 3: Post
+
+```bash
+gh issue comment <target_issue> --body "<comment>"
+```
+
+## Step 4: Report Result
+
+Output the issue URL and the posted comment.

--- a/.rulesync/commands/post-review-comments.md
+++ b/.rulesync/commands/post-review-comments.md
@@ -1,0 +1,43 @@
+---
+targets:
+  - "*"
+description: Post line-level review comments to a pull request
+---
+
+# Post Review Comments
+
+target_pr = $ARGUMENTS
+
+If `target_pr` is not provided, use the PR of the current branch. This command
+expects a set of review findings (for example, the output of `review-pr`).
+
+## Important: Do Not Switch the Local Branch
+
+Inspect the PR with read-only commands; do not check out or switch the branch.
+
+## Step 1: Map Findings to Locations
+
+For each finding, determine the file path and line number in the PR diff:
+
+```bash
+gh pr diff <target_pr>
+gh pr view <target_pr> --json files
+```
+
+## Step 2: Post Line-Level Comments
+
+Create a review with line-level comments via the GitHub API:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<target_pr>/comments \
+  -f body="<comment>" -f commit_id="<head_sha>" -f path="<file>" -F line=<line>
+```
+
+Get the head SHA with `gh pr view <target_pr> --json headRefOid --jq '.headRefOid'`.
+
+Each comment should clearly state the issue, its severity (low / mid / high /
+critical), and a suggested fix.
+
+## Step 3: Report Result
+
+Output the PR number and a summary of the comments posted.

--- a/.rulesync/commands/prs-awaiting-author.md
+++ b/.rulesync/commands/prs-awaiting-author.md
@@ -1,0 +1,34 @@
+---
+targets:
+  - "*"
+description: List open PRs where the ball is in the author's court
+---
+
+# PRs Awaiting Author
+
+List open pull requests that are waiting on the **author** to act (for example,
+changes requested, CI failing, or unresolved review comments).
+
+The maintainers for this repository are `dyoshikawa` and `cm-dyoshikawa`.
+
+## Step 1: List Open PRs
+
+```bash
+gh pr list --state open --json number,title,author,reviewDecision,isDraft,statusCheckRollup,updatedAt --limit 100
+```
+
+## Step 2: Determine Who Holds the Ball
+
+A PR is **awaiting the author** when any of the following is true:
+
+- `reviewDecision` is `CHANGES_REQUESTED`.
+- CI/status checks are failing (`statusCheckRollup`).
+- The PR is a draft (`isDraft` is true).
+
+PRs authored by the maintainers (`dyoshikawa` / `cm-dyoshikawa`) that are simply
+waiting for review are **not** in this list — those are awaiting the maintainer.
+
+## Step 3: Report Result
+
+Output a table: PR number, title, author, reason it is awaiting the author, and
+last-updated time, sorted by least-recently-updated first.

--- a/.rulesync/commands/prs-awaiting-maintainer.md
+++ b/.rulesync/commands/prs-awaiting-maintainer.md
@@ -1,0 +1,36 @@
+---
+targets:
+  - "*"
+description: List open PRs where the ball is in the maintainer's court
+---
+
+# PRs Awaiting Maintainer
+
+List open pull requests that are waiting on a **maintainer** to act (for
+example, ready for review with passing CI and no changes requested).
+
+The maintainers for this repository are `dyoshikawa` and `cm-dyoshikawa`.
+
+## Step 1: List Open PRs
+
+```bash
+gh pr list --state open --json number,title,author,reviewDecision,isDraft,statusCheckRollup,updatedAt --limit 100
+```
+
+## Step 2: Determine Who Holds the Ball
+
+A PR is **awaiting the maintainer** when all of the following are true:
+
+- It is not a draft (`isDraft` is false).
+- CI/status checks are passing (or not yet failing).
+- `reviewDecision` is not `CHANGES_REQUESTED` (i.e. it is `REVIEW_REQUIRED`,
+  `APPROVED` and awaiting merge, or no decision yet).
+
+Use `author_association` (`OWNER` / `MEMBER` / `COLLABORATOR`) to recognize
+maintainer-authored PRs when needed.
+
+## Step 3: Report Result
+
+Output a table: PR number, title, author, why it is awaiting the maintainer
+(needs review / approved and ready to merge), and last-updated time, sorted by
+least-recently-updated first.

--- a/.rulesync/commands/pull-main.md
+++ b/.rulesync/commands/pull-main.md
@@ -1,0 +1,28 @@
+---
+targets:
+  - "*"
+description: Switch to the default branch and pull the latest changes
+---
+
+# Pull Latest Main
+
+## Step 1: Switch to the Default Branch
+
+```bash
+git switch main
+```
+
+If the working tree has uncommitted changes, **stop and ask the user** how to
+proceed (stash, commit, or discard) before switching.
+
+## Step 2: Pull and Prune
+
+```bash
+git pull --prune
+```
+
+`--prune` removes local references to remote branches that have been deleted.
+
+## Step 3: Report Result
+
+Output the current `HEAD` commit and a short summary of what was pulled.

--- a/.rulesync/commands/review-and-comments.md
+++ b/.rulesync/commands/review-and-comments.md
@@ -1,0 +1,29 @@
+---
+targets:
+  - "*"
+description: Review a PR and then post the findings as line-level comments
+---
+
+# Review and Comment
+
+target_pr = $ARGUMENTS
+
+If `target_pr` is not provided, use the PR of the current branch.
+
+This command chains two steps: review the PR, then post the findings as
+line-level review comments.
+
+## Step 1: Review the PR
+
+Follow the `review-pr` command to review `$target_pr` for code quality and
+security issues. Collect the findings with their severity (low / mid / high /
+critical) and the file/line each one refers to.
+
+## Step 2: Post the Findings
+
+Follow the `post-review-comments` command to post each finding as a line-level
+comment on `$target_pr`.
+
+## Step 3: Report Result
+
+Output the PR number and a summary of the findings and comments posted.

--- a/.rulesync/commands/triage-issues.md
+++ b/.rulesync/commands/triage-issues.md
@@ -1,0 +1,48 @@
+---
+targets:
+  - "*"
+description: Apply appropriate labels to unlabeled GitHub issues
+---
+
+# Triage Issues
+
+## Step 1: Find Unlabeled Open Issues
+
+```bash
+gh issue list --state open --search "no:label" --json number,title,body --limit 100
+```
+
+## Step 2: Fetch the Available Labels
+
+```bash
+gh label list
+```
+
+Only use labels that actually exist in the repository.
+
+## Step 3: Classify Each Issue
+
+Read each issue and assign the labels that fit. The repository's standard
+labels and their meaning:
+
+- `bug` — something isn't working as intended.
+- `enhancement` — a new feature or request.
+- `documentation` — improvements or additions to documentation.
+- `question` — further information is requested.
+- `duplicate` — already tracked by another issue or PR.
+- `invalid` — does not seem to be a real/actionable issue.
+- `wontfix` — acknowledged but will not be worked on.
+- `good first issue` — small, approachable task suitable for newcomers.
+- `help wanted` — extra attention or external help is welcome.
+
+Add `good first issue` only when the task is genuinely small and well-scoped.
+
+## Step 4: Apply Labels
+
+```bash
+gh issue edit <issue_number> --add-label "<label1>,<label2>"
+```
+
+## Step 5: Report Result
+
+Output a table of issues and the labels applied to each.

--- a/.rulesync/skills/create-issue/SKILL.md
+++ b/.rulesync/skills/create-issue/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: create-issue
+description: "Create a GitHub issue with a detailed description, purpose, and appropriate labels"
+targets: ["*"]
+---
+
+# Create GitHub Issue
+
+## Step 1: Gather Information
+
+Receive the topic from `$ARGUMENTS`. If it is insufficient, ask for: what needs
+to be done (the task or problem) and why (the purpose or motivation).
+
+## Step 2: Research Context
+
+Investigate the relevant code: affected files/modules, related patterns, and the
+likely impact of the change.
+
+## Step 3: Draft the Issue
+
+All issue content (title, body, labels) must be written in English.
+
+```markdown
+## Summary
+
+A concise one-liner.
+
+## Motivation / Purpose
+
+Why this change is needed.
+
+## Details
+
+- Specific changes required
+- Files/modules likely affected
+- Acceptance criteria / expected behavior
+
+## Additional Context
+
+Links, screenshots, references (if applicable).
+```
+
+## Step 4: Assign Labels
+
+Run `gh label list`, then choose from the existing labels only. Add
+`good first issue` if the task is small and approachable and that label exists.
+
+## Step 5: Create
+
+```bash
+gh issue create --title "<title>" --body "<body>" --label "<l1>,<l2>"
+```
+
+## Step 6: Report Result
+
+Output the issue URL, title, and assigned labels.

--- a/cspell.json
+++ b/cspell.json
@@ -192,6 +192,7 @@
     "shellcheck",
     "trivyignores",
     "worktree",
-    "worktrees"
+    "worktrees",
+    "pipefail"
   ]
 }


### PR DESCRIPTION
## Summary

Ports the **generic, domain-independent** parts of the GitHub Actions workflow and rulesync `commands`/`skills` migration guides. The existing `ci` / `actionlint` / `trivy-security-scan` / `release` workflows and the existing rulesync commands/subagents are left untouched.

Domain-specific pieces from the guides were intentionally **excluded** as not applicable to this repository:

- scrap-issue automation (`auto-close-maintainer-scrap-issues`, scrap commands/skills) — no scrap workflow here
- `docs.yml` — no documentation site
- `publish.yml` — npm publish is already handled by `release.yml`
- `publish-assets` / `e2e-binaries` / `draft-release` / `security-scan` — binary distribution, AI automation, and LLM scanning are project-specific
- `git-config` / `minimize-comments` / `select-opencode-model` local actions — not needed

### Workflows

- **`ci-failure-reminder.yml`** — comments once on open PRs whose CI is failing (skips drafts/bots, dedupes per head SHA)
- **`auto-close-stale-prs.yml`** — closes PRs inactive for 30 days after leaving a comment
- **`pr-policy.yml`** — warns external contributors who exceed the added-lines (1000) or simultaneous-open-PR (2) limits; uses `pull_request_target` and **does not check out or run PR code**

All three follow the guide's hardening rules: minimal `permissions`, SHA-pinned actions, and no untrusted-input interpolation into `run` scripts.

### rulesync commands

Generated outputs (`.claude/commands/`, etc.) are gitignored, so only the `.rulesync/` sources are committed:

`approve`, `pull-main`, `diff-analyze`, `explain-issue`, `explain-pr`, `post-issue-comment`, `post-review-comments`, `triage-issues`, `prs-awaiting-author`, `prs-awaiting-maintainer`, `review-and-comments`

- `triage-issues` references this repository's actual label vocabulary (`bug`, `enhancement`, `documentation`, `question`, `duplicate`, `invalid`, `wontfix`, `good first issue`, `help wanted`)
- `prs-awaiting-*` use the maintainer logins `dyoshikawa` / `cm-dyoshikawa`

### rulesync skills

- `create-issue`

### Misc

- Add `pipefail` to the cspell dictionary

## Verification

- `cspell` and `secretlint` clean on all new files — no secret values (the only token reference is `secrets.GITHUB_TOKEN`, the standard built-in)
- workflow YAML validated with `js-yaml`
- pre-commit hook (secretlint + cspell) passed

## Follow-ups (not in this PR)

- `actionlint` was not run locally (external `curl | bash` install was blocked); the `actionlint.yml` workflow will validate the new files on push
- The `github-script` action hash (`v9.0.0`) may need bumping; Dependabot's `github-actions` ecosystem will track it
- Scheduled workflows can be exercised via `workflow_dispatch` before relying on cron
- This branch is based on `main`, so it does **not** include the in-flight oxlint/oxfmt migration from #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
