### PR TITLE
release: v0.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reviewprompt",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "description": "Unified AI rules management CLI tool that generates configuration files for various AI development tools",
     "keywords": [
         "ai",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name("reviewprompt")
   .description("GitHub PR review comments to AI prompt CLI tool")
-  .version("0.13.1");
+  .version("0.13.2");
 
 program
   .argument("<pr-url>", "GitHub PR URL")


### PR DESCRIPTION
Release v0.13.2.

Fixes the broken `0.13.1` npm package (published without `dist/`, causing `spawn reviewprompt ENOENT`) and ships the CLI e2e tests added in #35.

See `ai-tmp/release-notes.md` for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)